### PR TITLE
Add uuid import

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -1,3 +1,5 @@
+import uuid
+
 from charmhelpers.core import hookenv
 from charmhelpers.contrib.network import ip
 from charms.reactive import hook


### PR DESCRIPTION
This fixes the associated bug [LP:#1905511][1] where a "request_restart()"
method was added which references the required uuid module but no import
was added.  This broken the designate charm, unfortunately.

[1]: https://bugs.launchpad.net/charm-designate/+bug/1905511